### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,25 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1100.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.0.tgz",
-      "integrity": "sha512-JFPEpEgxJGk5eaJsEilQNI5rOAKCawMdGFAq1uBlYeXSt3iMfFfn//ayvIsE7L2y5b4MC0rzafWSNyDSP3+WuA==",
+      "version": "0.1100.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.1.tgz",
+      "integrity": "sha512-DIAvTRRY+k7T2xHf4RVV06P16D0V7wSf1MSpGSDWVpfWcA3HNOSGfsk1F+COMlbFehXuKztwieXarv5rXbBCng==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.0",
+        "@angular-devkit/core": "11.0.1",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1100.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1100.0.tgz",
-      "integrity": "sha512-jCgtnqfBLO00LNImqtjeW07ijYXdpzhsOM4jzlhafh/NesjWJXgg1NI1K7QJvmVL79TeqbBsMj8IOLGTMUCDJw==",
+      "version": "0.1100.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1100.1.tgz",
+      "integrity": "sha512-w8NcoXuruOHio0D/JbX47iDl9FVH8X9k/OlZ/rSNVQ3uEpV6uxIaTm3fZ1ZSrKffi+97rKEwpHOf2N0DXl4XGQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.0",
-        "@angular-devkit/build-optimizer": "0.1100.0",
-        "@angular-devkit/build-webpack": "0.1100.0",
-        "@angular-devkit/core": "11.0.0",
+        "@angular-devkit/architect": "0.1100.1",
+        "@angular-devkit/build-optimizer": "0.1100.1",
+        "@angular-devkit/build-webpack": "0.1100.1",
+        "@angular-devkit/core": "11.0.1",
         "@babel/core": "7.12.3",
         "@babel/generator": "7.12.1",
         "@babel/plugin-transform-runtime": "7.12.1",
@@ -31,7 +31,7 @@
         "@babel/runtime": "7.12.1",
         "@babel/template": "7.10.4",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.0.0",
+        "@ngtools/webpack": "11.0.1",
         "ansi-colors": "4.1.1",
         "autoprefixer": "9.8.6",
         "babel-loader": "8.1.0",
@@ -189,9 +189,9 @@
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1100.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.0.tgz",
-      "integrity": "sha512-RitDB5JCNDUN2CoNqf/FwLCwdWruApjxb7nUVb9C/uQgGEnrBojyxS/Rv/jCioom86s0sfY9wo79jdxd6AercQ==",
+      "version": "0.1100.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.1.tgz",
+      "integrity": "sha512-PpqBmDd+/cmaMj9MURe5pSSudo+Qz6BrGdzvYB16ekSp8bSDYLUriv5NvE/bm+ODKwo3jHgFrwWLiwK65vQcxQ==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
@@ -210,20 +210,20 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1100.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1100.0.tgz",
-      "integrity": "sha512-9diP/A6NtQxSxjbBMj9h9MHrAj4VqCvuFraR928eFaxEoRKcIwSTHhOiolRm+GL5V0VB+O53FRYDk3gC7BGjmQ==",
+      "version": "0.1100.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1100.1.tgz",
+      "integrity": "sha512-nfgsUfP6WyZ35rxgjqDYydB552Si/JdYLMtwy/kAFybW/6yTpw0sBOgCQoppyQ4mvVwyX9X0ZTQsMNhPOzy3sA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.0",
-        "@angular-devkit/core": "11.0.0",
+        "@angular-devkit/architect": "0.1100.1",
+        "@angular-devkit/core": "11.0.1",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.0.tgz",
-      "integrity": "sha512-fXZtSs3J4S12hboi3om1FA+QS0e8nuQMyzl2nkmtuhcELUFMmSrEl36dtCni5e7Svs46BUAZ5w8EazIkgGQDJg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.1.tgz",
+      "integrity": "sha512-ui3g7w/0SpU9oq8uwN9upR8Y1eOXZ+P2p3NyDydBrR7ZEfEkRLS1mhozN/ib8farrwK5N3kIIJxMb5t3187Hng==",
       "dev": true,
       "requires": {
         "ajv": "6.12.6",
@@ -260,12 +260,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.0.tgz",
-      "integrity": "sha512-oCz9E0thA5WdGDuv6biu3X5kw5/vNE4ZZOKT2sHBQMpAuuDYrDpfTYQJjXQtjfXWvmlr8L8aqDD9N4HXsE4Esw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.1.tgz",
+      "integrity": "sha512-rAOnAndcybEH398xf5wzmcUPCoCi0dKiOo/+1dkKU5aTxynw1OUnANt5K6A+ZZTGnJmfjtP0ovkZGYun9IUDxQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.0",
+        "@angular-devkit/core": "11.0.1",
         "ora": "5.1.0",
         "rxjs": "6.6.3"
       }
@@ -288,16 +288,16 @@
       }
     },
     "@angular/cli": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.0.0.tgz",
-      "integrity": "sha512-U9sh9r1CSqS78QjuosM3JDXUUTf8eVP1+kSchWEsxjJ0kfdvj7PvtKD1kmRH7HA5lD2q7QfGEvfHpfxMVzKxRg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.0.1.tgz",
+      "integrity": "sha512-zB20jTLQxLpkJjhbYelhRyMcgGsjwbD8pSYYAO6QX656Tx1tCtJ2UskEtf4ePQvgzu0Ds2dnAEfco+tekIMRTA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.0",
-        "@angular-devkit/core": "11.0.0",
-        "@angular-devkit/schematics": "11.0.0",
-        "@schematics/angular": "11.0.0",
-        "@schematics/update": "0.1100.0",
+        "@angular-devkit/architect": "0.1100.1",
+        "@angular-devkit/core": "11.0.1",
+        "@angular-devkit/schematics": "11.0.1",
+        "@schematics/angular": "11.0.1",
+        "@schematics/update": "0.1100.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.2.0",
@@ -778,9 +778,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.593",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.593.tgz",
-          "integrity": "sha512-GvO7G1ZxvffnMvPCr4A7+iQPVuvpyqMrx2VWSERAjG+pHK6tmO9XqYdBfMIq9corRyi4bNImSDEiDvIoDb8HrA==",
+          "version": "1.3.594",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.594.tgz",
+          "integrity": "sha512-mEax1P0CcoZJtXQU7OA0dO5nHiAQWw8gRGWKhnUyPA9bJW0B/JGiaQB+vtK66Ovm6U9qPxe2iXbO1L+f4jJAiw==",
           "dev": true
         },
         "node-releases": {
@@ -1788,12 +1788,12 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.0.0.tgz",
-      "integrity": "sha512-thWOXiMfyVUUWDDRUUAIvb5HASovX1C0GcxRBFE8fXJMCwOPIwqZiAyJJlUUnie8BEP9yC/x6uLCud56ai4Uaw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.0.1.tgz",
+      "integrity": "sha512-z62qQ4J5LhDxW68HjYYCRo+sDK/5yHwX4fCCY2iXngyTtA5cQbGI5WXr3+9B4foX64ft5WvV0WJkx8mjE/VR6w==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.0",
+        "@angular-devkit/core": "11.0.1",
         "enhanced-resolve": "5.3.1",
         "webpack-sources": "2.0.1"
       }
@@ -1943,24 +1943,24 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.0.tgz",
-      "integrity": "sha512-/4fkfryoCKQv7nnZgbQ/2aLg8418/SdrCi4ASN0xpfcj34oe2FqsKypeoJG+3bQVF8CLfseorvPNR2YINb4RQA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.1.tgz",
+      "integrity": "sha512-cYq3NhFn4DLSXXtbYYU2w0sginkMfN1w7pXjZLT/+etXXbtANQAXSPrPrDQql004ZNMbuDKuC0aoXjv8hgXOfw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.0",
-        "@angular-devkit/schematics": "11.0.0",
+        "@angular-devkit/core": "11.0.1",
+        "@angular-devkit/schematics": "11.0.1",
         "jsonc-parser": "2.3.1"
       }
     },
     "@schematics/update": {
-      "version": "0.1100.0",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1100.0.tgz",
-      "integrity": "sha512-61zhqIvKHiMR3nezM5FlUoWe2Lw2uKzmuSwcxA2d6SqjDXYyXrOSKmaPcbi7Emgh3VWsQadNpXuc5A2tbKCQhg==",
+      "version": "0.1100.1",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1100.1.tgz",
+      "integrity": "sha512-EVcqdM/d5rC5L1UYnwhFMk/TjHlNgL5LGfroE13C38A+WpKKJquAjgOQLj4nPvJ5csdEZqn3Sui9yeEWc3hklQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.0",
-        "@angular-devkit/schematics": "11.0.0",
+        "@angular-devkit/core": "11.0.1",
+        "@angular-devkit/schematics": "11.0.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "1.3.5",
         "npm-package-arg": "^8.0.0",
@@ -3978,9 +3978,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.593",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.593.tgz",
-          "integrity": "sha512-GvO7G1ZxvffnMvPCr4A7+iQPVuvpyqMrx2VWSERAjG+pHK6tmO9XqYdBfMIq9corRyi4bNImSDEiDvIoDb8HrA==",
+          "version": "1.3.594",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.594.tgz",
+          "integrity": "sha512-mEax1P0CcoZJtXQU7OA0dO5nHiAQWw8gRGWKhnUyPA9bJW0B/JGiaQB+vtK66Ovm6U9qPxe2iXbO1L+f4jJAiw==",
           "dev": true
         },
         "node-releases": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/itzrabbs/angular-2-dropdown-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1100.0",
+    "@angular-devkit/build-angular": "^0.1100.1",
     "@angular/animations": "11.0.0",
-    "@angular/cli": "^11.0.0",
+    "@angular/cli": "^11.0.1",
     "@angular/common": "11.0.0",
     "@angular/compiler": "11.0.0",
     "@angular/compiler-cli": "11.0.0",


### PR DESCRIPTION
[ng-update](https://github.com/itzrabbs/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 21 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular-devkit/build-angular      0.1100.0 -> 0.1100.1     ng update @angular-devkit/build-angular
      @angular/cli                       11.0.0 -> 11.0.1         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the addition packages by running the update command of your package manager.


  </summary>
</details>