### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,25 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1100.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.4.tgz",
-      "integrity": "sha512-hzTfcSUwM0jsSt9HvvSFyaoAhX9k73L7y4kmkghzIFhKhIKOp/7o3n7hAFwN/jWKKmVQpPKnYmqzm9H9OveaCQ==",
+      "version": "0.1100.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.5.tgz",
+      "integrity": "sha512-yOYfucNouc1doTbcGbCNMXGMSc36+j97XpdNoeGyzFQ7GwezLAro0a9gxc5PdOxndfelkND7J1JuOjxdW5O17A==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.4",
+        "@angular-devkit/core": "11.0.5",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1100.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1100.4.tgz",
-      "integrity": "sha512-qVkMbtOwlo+k8fvOBOwwfKWMx06k4I1qrdjpRYAoZCt3cdje4EBepSciLrHnTB+ouIqWxpEDfEXTYBS98tXbBg==",
+      "version": "0.1100.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1100.5.tgz",
+      "integrity": "sha512-lJYsnBImBAqUAIVC2qGY64UaC2uWOPZEpSWjYUxkRZA/c4IVCJj3M12CgONBjtcKYzFVXc1eojhrScukGIJJcg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.4",
-        "@angular-devkit/build-optimizer": "0.1100.4",
-        "@angular-devkit/build-webpack": "0.1100.4",
-        "@angular-devkit/core": "11.0.4",
+        "@angular-devkit/architect": "0.1100.5",
+        "@angular-devkit/build-optimizer": "0.1100.5",
+        "@angular-devkit/build-webpack": "0.1100.5",
+        "@angular-devkit/core": "11.0.5",
         "@babel/core": "7.12.3",
         "@babel/generator": "7.12.1",
         "@babel/plugin-transform-runtime": "7.12.1",
@@ -31,7 +31,7 @@
         "@babel/runtime": "7.12.1",
         "@babel/template": "7.10.4",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.0.4",
+        "@ngtools/webpack": "11.0.5",
         "ansi-colors": "4.1.1",
         "autoprefixer": "9.8.6",
         "babel-loader": "8.1.0",
@@ -171,9 +171,9 @@
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1100.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.4.tgz",
-      "integrity": "sha512-C05y4qMb05PWR7l1gZwRQKiB6KIDq+p72r8Yr6jm0UO6raOtMM72R8nHnioMnGJcFtZDEAYXEF+X7soI3MMlfw==",
+      "version": "0.1100.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.5.tgz",
+      "integrity": "sha512-aKITFuiydR681eS1z84EIdOtqdxP/V5xGZuF3xjGmg5Ddwv36PweAHaCVJEB4btHSWH6uxMvW2hLXg2RTWbRNg==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
@@ -192,20 +192,20 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1100.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1100.4.tgz",
-      "integrity": "sha512-uxe8gNSej3KF1FgqNtJmuRDbbINh3yLtXanXhRxFQLUj8IiNR8IciIVvy6RfXC5gqxcWwy1cOefJLLnuN9AOxQ==",
+      "version": "0.1100.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1100.5.tgz",
+      "integrity": "sha512-oD5t2oCfyiCyyeZckrqBnQco94zIMkRnRGzy3lFDH7KMiL0DG9l7x3nxn9H0YunYWr55LsGWwXGoR7l03Kl+jw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.4",
-        "@angular-devkit/core": "11.0.4",
+        "@angular-devkit/architect": "0.1100.5",
+        "@angular-devkit/core": "11.0.5",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/core": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.4.tgz",
-      "integrity": "sha512-LgTvhZ3Ycz0QvNAH/zO1rpQQDn2JN8u9/Awy1gW/XeCC3FYmxeOj/2JCFzlKah3wJv16nMqro5WTppHt8Y++PA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.5.tgz",
+      "integrity": "sha512-hwV8fjF8JNPJkiVWw8MNzeIfDo01aD/OAOlC4L5rQnVHn+i2EiU3brSDmFqyeHPPV3h/QjuBkS3tkN7gSnVWaQ==",
       "dev": true,
       "requires": {
         "ajv": "6.12.6",
@@ -242,12 +242,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.4.tgz",
-      "integrity": "sha512-fFC7qW9A1bFAZgpCfkezBA4WCRzfVFgOzwPpyt65rgSrzw0+EeHjcrUIcXlhyOXAFrTHtA9oLCfEeSjSx5HBEA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.5.tgz",
+      "integrity": "sha512-0NKGC8Nf/4vvDpWKB7bwxIazvNnNHnZBX6XlyBXNl+fW8tpTef3PNMJMSErTz9LFnuv61vsKbc36u/Ek2YChWg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.4",
+        "@angular-devkit/core": "11.0.5",
         "ora": "5.1.0",
         "rxjs": "6.6.3"
       }
@@ -270,20 +270,20 @@
       }
     },
     "@angular/cli": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.0.4.tgz",
-      "integrity": "sha512-VkE/gx6P80EJHg13fG+gkZfd2DJmRaDAtnamcCGM4AThzoUN9XBdxc24uMLEzBb0/mJ4vpMK9+WTNIdMmzl+Tg==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.0.5.tgz",
+      "integrity": "sha512-k4j/2z7qkuigJ1shH0McW1wW63clhrbrg98FK4/KWhU/sce5AgVjuHDQFycAclTwHesf7Vs6Gzt7zGlqUmeKIg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.4",
-        "@angular-devkit/core": "11.0.4",
-        "@angular-devkit/schematics": "11.0.4",
-        "@schematics/angular": "11.0.4",
-        "@schematics/update": "0.1100.4",
+        "@angular-devkit/architect": "0.1100.5",
+        "@angular-devkit/core": "11.0.5",
+        "@angular-devkit/schematics": "11.0.5",
+        "@schematics/angular": "11.0.5",
+        "@schematics/update": "0.1100.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.2.0",
-        "ini": "1.3.5",
+        "ini": "1.3.6",
         "inquirer": "7.3.3",
         "npm-package-arg": "8.1.0",
         "npm-pick-manifest": "6.1.0",
@@ -305,6 +305,12 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "ini": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.6.tgz",
+          "integrity": "sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg==",
+          "dev": true
         },
         "resolve": {
           "version": "1.18.1",
@@ -714,28 +720,28 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.15.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
-          "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
+          "version": "4.16.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+          "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001164",
+            "caniuse-lite": "^1.0.30001165",
             "colorette": "^1.2.1",
-            "electron-to-chromium": "^1.3.612",
+            "electron-to-chromium": "^1.3.621",
             "escalade": "^3.1.1",
             "node-releases": "^1.1.67"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001165",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-          "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
+          "version": "1.0.30001168",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
+          "integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.621",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.621.tgz",
-          "integrity": "sha512-FeIuBzArONbAmKmZIsZIFGu/Gc9AVGlVeVbhCq+G2YIl6QkT0TDn2HKN/FMf1btXEB9kEmIuQf3/lBTVAbmFOg==",
+          "version": "1.3.629",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.629.tgz",
+          "integrity": "sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ==",
           "dev": true
         },
         "node-releases": {
@@ -931,9 +937,9 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+      "integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
@@ -1247,9 +1253,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
-      "integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
+      "integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1732,12 +1738,12 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.0.4.tgz",
-      "integrity": "sha512-MAV7inQmsMISTnDcXwyRX5oJZx8F7K/tZRLJciQwkM0DqZyq8fI9KDRwBcmYeQ+J0mSJV9LUVdExmpulpkywqw==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.0.5.tgz",
+      "integrity": "sha512-hM0LdOSlC6c7ij+BvIpAFbe7dpJhL+A51L5v6YbMA6aM0Sb/y+HpE2u34AHEQvute7cLe4EyOyvJ9jSinVAJhQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.4",
+        "@angular-devkit/core": "11.0.5",
         "enhanced-resolve": "5.3.1",
         "webpack-sources": "2.0.1"
       }
@@ -1887,32 +1893,38 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.4.tgz",
-      "integrity": "sha512-LwBD9TIoLy9XqqInJvlN4BHtPyJExyeorNiOp6rXb/wafuDbvZ+9kY9GWZTY1auVo5PNKqErfxr74ydA3FFb9g==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.5.tgz",
+      "integrity": "sha512-7p2wweoJYhim8YUy3ih1SrPGqRsa6+aEFbYgo9v4zt7b3tOva8SvkbC2alayK74fclzQ7umqa6xAwvWhy8ORvg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.4",
-        "@angular-devkit/schematics": "11.0.4",
+        "@angular-devkit/core": "11.0.5",
+        "@angular-devkit/schematics": "11.0.5",
         "jsonc-parser": "2.3.1"
       }
     },
     "@schematics/update": {
-      "version": "0.1100.4",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1100.4.tgz",
-      "integrity": "sha512-YwFtgxCQQkYC89IC7dfshyGr0roE6bpp5HgpQLdS/AOjHeZKo7/SPdM0W4ddB+Fml1Fo6v4eFG/Ia9oR7qNv1A==",
+      "version": "0.1100.5",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1100.5.tgz",
+      "integrity": "sha512-BYtKKuiWsrlc4FMW3bRyl4tm6lWNMTi8oql/mtkSgH7V5eMmaLDJtM+zDl+qyC/KHPxbHTfoHDapfv1tITSWjA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.4",
-        "@angular-devkit/schematics": "11.0.4",
+        "@angular-devkit/core": "11.0.5",
+        "@angular-devkit/schematics": "11.0.5",
         "@yarnpkg/lockfile": "1.1.0",
-        "ini": "1.3.5",
+        "ini": "1.3.6",
         "npm-package-arg": "^8.0.0",
         "pacote": "9.5.12",
         "semver": "7.3.2",
         "semver-intersect": "1.4.0"
       },
       "dependencies": {
+        "ini": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.6.tgz",
+          "integrity": "sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -3829,28 +3841,28 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.15.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
-          "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
+          "version": "4.16.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+          "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001164",
+            "caniuse-lite": "^1.0.30001165",
             "colorette": "^1.2.1",
-            "electron-to-chromium": "^1.3.612",
+            "electron-to-chromium": "^1.3.621",
             "escalade": "^3.1.1",
             "node-releases": "^1.1.67"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001165",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-          "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
+          "version": "1.0.30001168",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
+          "integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.621",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.621.tgz",
-          "integrity": "sha512-FeIuBzArONbAmKmZIsZIFGu/Gc9AVGlVeVbhCq+G2YIl6QkT0TDn2HKN/FMf1btXEB9kEmIuQf3/lBTVAbmFOg==",
+          "version": "1.3.629",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.629.tgz",
+          "integrity": "sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ==",
           "dev": true
         },
         "node-releases": {
@@ -5425,9 +5437,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
       "dev": true
     },
     "for-in": {
@@ -5870,9 +5882,9 @@
       "dev": true
     },
     "html-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.3.tgz",
+      "integrity": "sha512-/VulV3SYni1taM7a4RMdceqzJWR39gpZHjBwUnsCFKWV/GJkD14CJ5F7eWcZozmHJK0/f/H5U3b3SiPkuvxMgg==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -13295,9 +13307,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "version": "2.4.7",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+          "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/itzrabbs/angular-2-dropdown-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1100.4",
+    "@angular-devkit/build-angular": "^0.1100.5",
     "@angular/animations": "11.0.5",
-    "@angular/cli": "^11.0.4",
+    "@angular/cli": "^11.0.5",
     "@angular/common": "11.0.5",
     "@angular/compiler": "11.0.5",
     "@angular/compiler-cli": "11.0.5",


### PR DESCRIPTION
[ng-update](https://github.com/itzrabbs/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 21 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       11.0.4 -> 11.0.5         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the addition packages by running the update command of your package manager.


  </summary>
</details>