### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,25 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1100.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.6.tgz",
-      "integrity": "sha512-4O+cg3AimI2bNAxxdu5NrqSf4Oa8r8xL0+G2Ycd3jLoFv0h0ecJiNKEG5F6IpTprb4aexZD6pcxBJCqQ8MmzWQ==",
+      "version": "0.1100.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.7.tgz",
+      "integrity": "sha512-b2zv2yiRbdhJ7hJfZsAvGYcqgh2DVtc7gRIPo1eDPvOAKrenmZ4zo/v0PRYScrTsPzqmoCokNA5nIwufwUEnuA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.6",
+        "@angular-devkit/core": "11.0.7",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1100.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1100.6.tgz",
-      "integrity": "sha512-HcqsWiSIUxExGg3HRQScLOmF+ckVkCKolfpPcNOCCpBYxH/i8n4wDGLBP5Rtxky+0Qz+3nnAaFIpNb9p9aUmbg==",
+      "version": "0.1100.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1100.7.tgz",
+      "integrity": "sha512-erc+AtSU46ZIX7A5dmeZ0/G/SQIbqMAGbTKZbf11GePyhT0JAAnfMQtOHMb6AaX85n4yQTg1uMo9f5+8V3lfKA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.6",
-        "@angular-devkit/build-optimizer": "0.1100.6",
-        "@angular-devkit/build-webpack": "0.1100.6",
-        "@angular-devkit/core": "11.0.6",
+        "@angular-devkit/architect": "0.1100.7",
+        "@angular-devkit/build-optimizer": "0.1100.7",
+        "@angular-devkit/build-webpack": "0.1100.7",
+        "@angular-devkit/core": "11.0.7",
         "@babel/core": "7.12.3",
         "@babel/generator": "7.12.1",
         "@babel/plugin-transform-runtime": "7.12.1",
@@ -31,7 +31,7 @@
         "@babel/runtime": "7.12.1",
         "@babel/template": "7.10.4",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.0.6",
+        "@ngtools/webpack": "11.0.7",
         "ansi-colors": "4.1.1",
         "autoprefixer": "9.8.6",
         "babel-loader": "8.1.0",
@@ -171,9 +171,9 @@
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1100.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.6.tgz",
-      "integrity": "sha512-Qkq7n6510N+nXmfZqpqpI0I6Td+b+06RRNmS7KftSNJntU1z5QYh4FggwlthZ5P0QUT92cnBQsnT8OgYqGnwbg==",
+      "version": "0.1100.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.7.tgz",
+      "integrity": "sha512-bHIIub0d1trVAmAX/EaNR6Zo4b7hkscewK394qYYp/w8VKQkLSAPMUbt2YTWN+erR9yyHnJ2y7tBabIui75Wdw==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
@@ -192,20 +192,20 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1100.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1100.6.tgz",
-      "integrity": "sha512-kK0FlpYJHP25o1yzIGHQqIvO5kp+p6V5OwGpD2GGRZLlJqd3WdjY5DxnyZoX3/IofO6KsTnmm76fzTRqc62z/Q==",
+      "version": "0.1100.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1100.7.tgz",
+      "integrity": "sha512-/6Hudd1hs/GMHX4C/Qk7jueIMNg8NKFJWDEbvMPMgDzTqUIa680PTD6SNSCcY5Cz9mEpdpYCZo5N31JB7dlpOg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.6",
-        "@angular-devkit/core": "11.0.6",
+        "@angular-devkit/architect": "0.1100.7",
+        "@angular-devkit/core": "11.0.7",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/core": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.6.tgz",
-      "integrity": "sha512-nhvU5hH01r9qcexAqvIFU233treWWeW3ncs9UFYjD9Hys9sDSvqC3+bvGvl9vCG5FsyY7oDsjaVAipyUc+SFAg==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.7.tgz",
+      "integrity": "sha512-1GKnIT++YSUHpzzRx9QC0+8yOw4wy+ZpiJVDlroPSeK4FGrTCJqJKenkfRjVFRFOSrzTiJds+IU6kI4+bFbw9g==",
       "dev": true,
       "requires": {
         "ajv": "6.12.6",
@@ -242,12 +242,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.6.tgz",
-      "integrity": "sha512-hCyu/SSSiC6dKl/NxdWctknIrBqKR6pRe7DMArWowrZX6P9oi36LpKEFnKutE8+tXjsOqQj8XMBq9L64sXZWqg==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.7.tgz",
+      "integrity": "sha512-mKkXWmSTlZYjQO4i7xUX+bG1E9h9Ke3GgGQQouA+kth06IPO+VcywLQNsui4qcyLDUjyo8CaX+44aoSXoX3Tgg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.6",
+        "@angular-devkit/core": "11.0.7",
         "ora": "5.1.0",
         "rxjs": "6.6.3"
       }
@@ -270,16 +270,16 @@
       }
     },
     "@angular/cli": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.0.6.tgz",
-      "integrity": "sha512-bwrXXyU23HjUlFl0CNCU+XMGa/enooqpMLcTAA15StVpKFHyaA4c57il/aqu+1IuB+zR6rGDzhAABuvRcHd+mQ==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.0.7.tgz",
+      "integrity": "sha512-gKHfkkjduNi5OFaEKd75UKpZ7gg9h2+eVoo7ufrZda87PLP7v/XB/QoFz9zj6tTM2/IWkKhJhcsE2MLyIOTUZA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1100.6",
-        "@angular-devkit/core": "11.0.6",
-        "@angular-devkit/schematics": "11.0.6",
-        "@schematics/angular": "11.0.6",
-        "@schematics/update": "0.1100.6",
+        "@angular-devkit/architect": "0.1100.7",
+        "@angular-devkit/core": "11.0.7",
+        "@angular-devkit/schematics": "11.0.7",
+        "@schematics/angular": "11.0.7",
+        "@schematics/update": "0.1100.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.2.0",
@@ -727,15 +727,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001173",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
-          "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
+          "version": "1.0.30001177",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz",
+          "integrity": "sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.634",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz",
-          "integrity": "sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==",
+          "version": "1.3.639",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz",
+          "integrity": "sha512-bwl6/U6xb3d3CNufQU9QeO1L32ueouFwW4bWANSwdXR7LVqyLzWjNbynoKNfuC38QFB5Qn7O0l2KLqBkcXnC3Q==",
           "dev": true
         },
         "node-releases": {
@@ -1762,12 +1762,12 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.0.6.tgz",
-      "integrity": "sha512-vf5YNEpXWRa0fKC/BRq5sVVj2WnEqW8jn14YQRHwVt5ppUeyu8IKUF69p6W1MwZMgMqMaw/vPQ8LI5cFbyf3uw==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.0.7.tgz",
+      "integrity": "sha512-OWGiiDc7s4T53BBCY8tLkLUjgw44HrixW8Wh8e4thFH1eIUM0NHe087s/B5hDNu72W/GqK4IoBbhNQ2wiCR7qQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.6",
+        "@angular-devkit/core": "11.0.7",
         "enhanced-resolve": "5.3.1",
         "webpack-sources": "2.0.1"
       }
@@ -1799,12 +1799,13 @@
       }
     },
     "@npmcli/move-file": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
-      "integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.0.tgz",
+      "integrity": "sha512-Iv2iq0JuyYjKeFkSR4LPaCdDZwlGK9X2cP/01nJcp3yMJ1FjNd9vpiEYvLUgzBxKPg2SFmaOhizoQsPc0LWeOQ==",
       "dev": true,
       "requires": {
-        "mkdirp": "^1.0.4"
+        "mkdirp": "^1.0.4",
+        "rimraf": "^2.7.1"
       },
       "dependencies": {
         "mkdirp": {
@@ -1812,6 +1813,15 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -1917,24 +1927,24 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.6.tgz",
-      "integrity": "sha512-XUcpOrlcp55PBHrgpIVx69lnhDY6ro35BSRmqNmjXik56qcOkfvdki8vvyW9EsWvu9/sfBSsVDdparlbVois7w==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.7.tgz",
+      "integrity": "sha512-h8ZmHJvMcvre3rzaDBu1b5RxaaBe008kcniFNeks5nHTQRqDL/5Thg4YhIgH9VQ9Yf8U4atLjRJK5PG1OzmgDA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.6",
-        "@angular-devkit/schematics": "11.0.6",
+        "@angular-devkit/core": "11.0.7",
+        "@angular-devkit/schematics": "11.0.7",
         "jsonc-parser": "2.3.1"
       }
     },
     "@schematics/update": {
-      "version": "0.1100.6",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1100.6.tgz",
-      "integrity": "sha512-+B8n+k+zZ3VYOhjNBsLqzjp8O9ZdUWgdpf9L8XAA7mh/oPwufXpExyEc66uAS07imvUMmjz6i8E2eNWV/IjBJg==",
+      "version": "0.1100.7",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1100.7.tgz",
+      "integrity": "sha512-DXxWr4FwzhhpzDLivpA/QgXrnBHLSL5EQHcLLRylg3TISJFGKEQGYMYPw5V2ZS43hPM2zoJI/Dkcoo/PHBmNYw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.0.6",
-        "@angular-devkit/schematics": "11.0.6",
+        "@angular-devkit/core": "11.0.7",
+        "@angular-devkit/schematics": "11.0.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "1.3.6",
         "npm-package-arg": "^8.0.0",
@@ -3142,13 +3152,13 @@
       }
     },
     "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       }
     },
     "caller-callsite": {
@@ -3872,15 +3882,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001173",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
-          "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
+          "version": "1.0.30001177",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz",
+          "integrity": "sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.634",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz",
-          "integrity": "sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==",
+          "version": "1.3.639",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz",
+          "integrity": "sha512-bwl6/U6xb3d3CNufQU9QeO1L32ueouFwW4bWANSwdXR7LVqyLzWjNbynoKNfuC38QFB5Qn7O0l2KLqBkcXnC3Q==",
           "dev": true
         },
         "node-releases": {
@@ -10440,9 +10450,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.6.tgz",
+      "integrity": "sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
@@ -12002,9 +12012,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -13063,9 +13073,9 @@
           "dev": true
         },
         "enhanced-resolve": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-          "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/itzrabbs/angular-2-dropdown-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1100.6",
+    "@angular-devkit/build-angular": "^0.1100.7",
     "@angular/animations": "11.0.9",
-    "@angular/cli": "^11.0.6",
+    "@angular/cli": "^11.0.7",
     "@angular/common": "11.0.9",
     "@angular/compiler": "11.0.9",
     "@angular/compiler-cli": "11.0.9",


### PR DESCRIPTION
[ng-update](https://github.com/itzrabbs/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 21 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       11.0.6 -> 11.0.7         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>