### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,25 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1101.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.0.tgz",
-      "integrity": "sha512-Lj1STrxPXvvZVIk9RSTOPEiJeE/PGbBSclz12u92F3DsmbhcCxpiZ8AU8bUvJJ8gsZhGRB0BjPN0gCSWr9Po7w==",
+      "version": "0.1101.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.1.tgz",
+      "integrity": "sha512-oyzDIzI5owzYmgwGQLBbKOkTDc49dPosI2BiBf0oWtKH2L2sQ6jiad1k/Oq4/k7TYEN8neb/eZ1dpsHmZdYqaw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.0",
+        "@angular-devkit/core": "11.1.1",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1101.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.0.tgz",
-      "integrity": "sha512-oTCdHHyP/Z1cPnvJSHsQFD1FbLHI9AV7wYbDQ2UHpQFXg7OFzRWSro2aG54FMe6nD+gbXhQUmRryRsiNkCG71A==",
+      "version": "0.1101.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.1.tgz",
+      "integrity": "sha512-ftGjlk1qkOGhjeusYhgKhZ6EejrLVTKsvuNdygCNyK/RjISsgXowgolFdm1Yysgxdr859QAIZzMQoArnWZ2+rQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.0",
-        "@angular-devkit/build-optimizer": "0.1101.0",
-        "@angular-devkit/build-webpack": "0.1101.0",
-        "@angular-devkit/core": "11.1.0",
+        "@angular-devkit/architect": "0.1101.1",
+        "@angular-devkit/build-optimizer": "0.1101.1",
+        "@angular-devkit/build-webpack": "0.1101.1",
+        "@angular-devkit/core": "11.1.1",
         "@babel/core": "7.12.10",
         "@babel/generator": "7.12.11",
         "@babel/plugin-transform-runtime": "7.12.10",
@@ -31,7 +31,7 @@
         "@babel/runtime": "7.12.5",
         "@babel/template": "7.12.7",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.1.0",
+        "@ngtools/webpack": "11.1.1",
         "ansi-colors": "4.1.1",
         "autoprefixer": "10.2.1",
         "babel-loader": "8.2.2",
@@ -51,7 +51,7 @@
         "jest-worker": "26.6.2",
         "karma-source-map-support": "1.4.0",
         "less": "4.1.0",
-        "less-loader": "7.2.1",
+        "less-loader": "7.3.0",
         "license-webpack-plugin": "2.3.11",
         "loader-utils": "2.0.0",
         "mini-css-extract-plugin": "1.3.3",
@@ -62,7 +62,7 @@
         "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.2.4",
         "postcss-import": "14.0.0",
-        "postcss-loader": "4.1.0",
+        "postcss-loader": "4.2.0",
         "raw-loader": "4.0.2",
         "regenerator-runtime": "0.13.7",
         "resolve-url-loader": "3.1.2",
@@ -135,9 +135,9 @@
               }
             },
             "caniuse-lite": {
-              "version": "1.0.30001178",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz",
-              "integrity": "sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==",
+              "version": "1.0.30001179",
+              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
+              "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
               "dev": true
             }
           }
@@ -168,9 +168,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.642",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.642.tgz",
-          "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==",
+          "version": "1.3.643",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.643.tgz",
+          "integrity": "sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==",
           "dev": true
         },
         "glob": {
@@ -320,9 +320,9 @@
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1101.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.0.tgz",
-      "integrity": "sha512-0hkb7fVBDOMBmLA0NC394PAAZmQ1xo12UeiDwfNN2LF9pYdASVj/OSCcZ3yEfnxzBZm5qeNLJG2c4l2xB5NFPQ==",
+      "version": "0.1101.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.1.tgz",
+      "integrity": "sha512-kmzXmmjAOB0MdYFkx9gx+U80ZpVeKOHUCNPsR7/fNptP+O+anamSlT1vqQFkB+ykqYblXOzgJ06jMG7bFzTuxA==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
@@ -337,30 +337,24 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
           "dev": true
-        },
-        "typescript": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-          "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-          "dev": true
         }
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1101.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.0.tgz",
-      "integrity": "sha512-oIjRo/zRNqWQbKH/N/S8FZz6u1ADnX9IDML5mu8IucquGnZIqQVrrKeBnldtHQsIbN3TYYskO9xr9OS/W6VHqg==",
+      "version": "0.1101.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.1.tgz",
+      "integrity": "sha512-IiZPM4Brs76fOar8WodXYChvKXW5fMbLKlxvTzFFfdhKukpXXNwmuAWRl4PZ/Xt6tpEASG/r4BgN6/iu4DtJ9w==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.0",
-        "@angular-devkit/core": "11.1.0",
+        "@angular-devkit/architect": "0.1101.1",
+        "@angular-devkit/core": "11.1.1",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/core": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.0.tgz",
-      "integrity": "sha512-O2oIcqpQKGvYJH88d/NCgLYZGc9laA1eo2d1s0FH1Udu4c2L+bAsviQqtTKNmzyaqODHrlkt+eKx7uakdwWtnQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.1.tgz",
+      "integrity": "sha512-eQTRmcuVCgGE7mR3qyabjlvXlQCMDI+gDCkcAlzn161pJY9Yxmw0Q1rXN2sZlUdfZuc9sSg0m2MaQQFBSGp+XA==",
       "dev": true,
       "requires": {
         "ajv": "6.12.6",
@@ -397,12 +391,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.0.tgz",
-      "integrity": "sha512-6qfR5w1jyk8MC+5Tfimz+Czsq3WlsVoB57dpxSZfhGGsv1Vxc8Q41y5f3BrAyEqHYjcH7NtaoLQoJjtra5KaAg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.1.tgz",
+      "integrity": "sha512-XYbC0cGPChdXg0LD9EA08W24Rv5GPxGNGJNRQhUwlcU9L/szhOw9NEhr/l/DLijAxKv0J2eM5CuzKI1O/3tZYg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.0",
+        "@angular-devkit/core": "11.1.1",
         "ora": "5.2.0",
         "rxjs": "6.6.3"
       },
@@ -507,16 +501,16 @@
       }
     },
     "@angular/cli": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.1.0.tgz",
-      "integrity": "sha512-9QirgfU7+scdi2UASSlEdqkp1Jva3IiesIUIuxeF7scrFCnk/rZIJ9iSvPJ9qUXYpFYyxpX0aPEBvM/HDExeFQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.1.1.tgz",
+      "integrity": "sha512-2nRx9KYzLVCtJA4pgDmxubHOp54O/74BYt3WGHAA7QcnSATEL7jF5a9SMoEAJ2sUtKUVVS+2dKbmYKwW6oL3Bw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.0",
-        "@angular-devkit/core": "11.1.0",
-        "@angular-devkit/schematics": "11.1.0",
-        "@schematics/angular": "11.1.0",
-        "@schematics/update": "0.1101.0",
+        "@angular-devkit/architect": "0.1101.1",
+        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/schematics": "11.1.1",
+        "@schematics/angular": "11.1.1",
+        "@schematics/update": "0.1101.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.3.1",
@@ -964,15 +958,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001178",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz",
-          "integrity": "sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==",
+          "version": "1.0.30001179",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
+          "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.642",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.642.tgz",
-          "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==",
+          "version": "1.3.643",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.643.tgz",
+          "integrity": "sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==",
           "dev": true
         },
         "node-releases": {
@@ -1968,12 +1962,12 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.0.tgz",
-      "integrity": "sha512-6KRuSCwDEtwht3mdo9jps01u00675sv9lovlIQ9eIluPq32GM0BweDtxpS/CPgON/Hp9I5Aqtb3z2obnU3EQ7Q==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.1.tgz",
+      "integrity": "sha512-SoqZU8qNESwuJbiYJoRhp/aMyWeK4HClkwotqkM/bPUnnOOCRvDYP20vYhATivF8Y8xOL7wktdd1HOtFvtbvlA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.0",
+        "@angular-devkit/core": "11.1.1",
         "enhanced-resolve": "5.6.0",
         "webpack-sources": "2.2.0"
       }
@@ -2223,24 +2217,24 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.0.tgz",
-      "integrity": "sha512-g04TcC1gLS1ptFYdIO7qZ+lJARBXoK9g+m5KzQoogdrDkCum+wN15bfYKc5hF8cDYQOOqYjRF5GBdS9Uvc4ulQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.1.tgz",
+      "integrity": "sha512-K4G+PwCIGYE6aw28ZcqAhw+qI6I8d8qtE3D1Vd4MPVuguDWpNEaB0Y+TIYWzukh5bmOqdl9m/fkw6eZeOglUuQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.0",
-        "@angular-devkit/schematics": "11.1.0",
+        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/schematics": "11.1.1",
         "jsonc-parser": "3.0.0"
       }
     },
     "@schematics/update": {
-      "version": "0.1101.0",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1101.0.tgz",
-      "integrity": "sha512-WcbiTcn+Rr1uYllTLMbYcMfiz5IRZ7OAapISA82DpDkBeYIUf86ANjkEK1qsuU3zoz5i3CbiWvPq/KTlrzh6dg==",
+      "version": "0.1101.1",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1101.1.tgz",
+      "integrity": "sha512-BmGxxAH05ey8rc0gQpMJ7hAJyr7bM172MStpIws+MLugxZ6a6jH8vI1+MpnrqE0TK1PIPx6vclCMgf3RbQEzIw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.0",
-        "@angular-devkit/schematics": "11.1.0",
+        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/schematics": "11.1.1",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "2.0.0",
         "npm-package-arg": "^8.0.0",
@@ -4231,15 +4225,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001178",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz",
-          "integrity": "sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==",
+          "version": "1.0.30001179",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
+          "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.642",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.642.tgz",
-          "integrity": "sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==",
+          "version": "1.3.643",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.643.tgz",
+          "integrity": "sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==",
           "dev": true
         },
         "node-releases": {
@@ -7485,9 +7479,9 @@
       }
     },
     "less-loader": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-7.2.1.tgz",
-      "integrity": "sha512-4v83WZ7KGbluOWPgk3iNjreAaJDNStfmmdfJbQIib3Jlc8mejV3w6A9xU+EkaivjBVqwQEK0y8cFthyNeGnrTQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-7.3.0.tgz",
+      "integrity": "sha512-Mi8915g7NMaLlgi77mgTTQvK022xKRQBIVDSyfl3ErTuBhmZBQab0mjeJjNNqGbdR+qrfTleKXqbGI4uEFavxg==",
       "dev": true,
       "requires": {
         "klona": "^2.0.4",
@@ -9628,16 +9622,16 @@
       }
     },
     "postcss-loader": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.1.0.tgz",
-      "integrity": "sha512-vbCkP70F3Q9PIk6d47aBwjqAMI4LfkXCoyxj+7NPNuVIwfTGdzv2KVQes59/RuxMniIgsYQCFSY42P3+ykJfaw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.2.0.tgz",
+      "integrity": "sha512-mqgScxHqbiz1yxbnNcPdKYo/6aVt+XExURmEbQlviFVWogDbM4AJ0A/B+ZBpYsJrTRxKw7HyRazg9x0Q9SWwLA==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7.0.0",
         "klona": "^2.0.4",
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0",
-        "semver": "^7.3.2"
+        "semver": "^7.3.4"
       },
       "dependencies": {
         "ajv": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/itzrabbs/angular-2-dropdown-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1101.0",
+    "@angular-devkit/build-angular": "^0.1101.1",
     "@angular/animations": "11.1.0",
-    "@angular/cli": "^11.1.0",
+    "@angular/cli": "^11.1.1",
     "@angular/common": "11.1.0",
     "@angular/compiler": "11.1.0",
     "@angular/compiler-cli": "11.1.0",


### PR DESCRIPTION
[ng-update](https://github.com/itzrabbs/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 21 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       11.1.0 -> 11.1.1         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>