### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,25 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1101.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.1.tgz",
-      "integrity": "sha512-oyzDIzI5owzYmgwGQLBbKOkTDc49dPosI2BiBf0oWtKH2L2sQ6jiad1k/Oq4/k7TYEN8neb/eZ1dpsHmZdYqaw==",
+      "version": "0.1101.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.2.tgz",
+      "integrity": "sha512-MLmBfHiiyPhbFSSAX4oMecPjEuBauOui5uBpI6BKNnk/7783fznbkbAKjXlOco7M81gkNeEoHMR8c+mOfcvv7g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/core": "11.1.2",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1101.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.1.tgz",
-      "integrity": "sha512-ftGjlk1qkOGhjeusYhgKhZ6EejrLVTKsvuNdygCNyK/RjISsgXowgolFdm1Yysgxdr859QAIZzMQoArnWZ2+rQ==",
+      "version": "0.1101.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.2.tgz",
+      "integrity": "sha512-EVJ7kAgy+sMnliCmHwN1niVeM7YaAvTMkF+ahImNfQRSQOW+QJ4F8vjiLtuARC6R02Yc5QPzELTHVPxC4Qll/A==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.1",
-        "@angular-devkit/build-optimizer": "0.1101.1",
-        "@angular-devkit/build-webpack": "0.1101.1",
-        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/architect": "0.1101.2",
+        "@angular-devkit/build-optimizer": "0.1101.2",
+        "@angular-devkit/build-webpack": "0.1101.2",
+        "@angular-devkit/core": "11.1.2",
         "@babel/core": "7.12.10",
         "@babel/generator": "7.12.11",
         "@babel/plugin-transform-runtime": "7.12.10",
@@ -31,7 +31,7 @@
         "@babel/runtime": "7.12.5",
         "@babel/template": "7.12.7",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.1.1",
+        "@ngtools/webpack": "11.1.2",
         "ansi-colors": "4.1.1",
         "autoprefixer": "10.2.1",
         "babel-loader": "8.2.2",
@@ -47,6 +47,7 @@
         "file-loader": "6.2.0",
         "find-cache-dir": "3.3.1",
         "glob": "7.1.6",
+        "https-proxy-agent": "5.0.0",
         "inquirer": "7.3.3",
         "jest-worker": "26.6.2",
         "karma-source-map-support": "1.4.0",
@@ -92,6 +93,15 @@
         "worker-plugin": "5.0.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -135,9 +145,9 @@
               }
             },
             "caniuse-lite": {
-              "version": "1.0.30001179",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
-              "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
+              "version": "1.0.30001180",
+              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz",
+              "integrity": "sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==",
               "dev": true
             }
           }
@@ -168,9 +178,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.643",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.643.tgz",
-          "integrity": "sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==",
+          "version": "1.3.648",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.648.tgz",
+          "integrity": "sha512-4POzwyQ80tkDiBwkxn7IpfzioimrjRSFX1sCQ3pLZsYJ5ERYmwzdq0hZZ3nFP7Z6GtmnSn3xwWDm8FPlMeOoEQ==",
           "dev": true
         },
         "glob": {
@@ -192,6 +202,16 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
         },
         "less": {
           "version": "4.1.0",
@@ -320,9 +340,9 @@
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1101.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.1.tgz",
-      "integrity": "sha512-kmzXmmjAOB0MdYFkx9gx+U80ZpVeKOHUCNPsR7/fNptP+O+anamSlT1vqQFkB+ykqYblXOzgJ06jMG7bFzTuxA==",
+      "version": "0.1101.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.2.tgz",
+      "integrity": "sha512-ARcUcEwaAR3n0gUq2hCx4eXONdnKKXTYSaw2GUHtraBDp+m/vFcE6Ufxyki453eHbHtaQ9yjXOcBqu86u1u8hA==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
@@ -341,20 +361,20 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1101.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.1.tgz",
-      "integrity": "sha512-IiZPM4Brs76fOar8WodXYChvKXW5fMbLKlxvTzFFfdhKukpXXNwmuAWRl4PZ/Xt6tpEASG/r4BgN6/iu4DtJ9w==",
+      "version": "0.1101.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.2.tgz",
+      "integrity": "sha512-T8+LjKdxk1faQA4Dh3PYkRbIBLE6Tjv5SNZmdDXpvGoyxS9FmLgLDXQZqXkYgiAHwH6PxhoQX4iVxkHHFkkHog==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.1",
-        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/architect": "0.1101.2",
+        "@angular-devkit/core": "11.1.2",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/core": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.1.tgz",
-      "integrity": "sha512-eQTRmcuVCgGE7mR3qyabjlvXlQCMDI+gDCkcAlzn161pJY9Yxmw0Q1rXN2sZlUdfZuc9sSg0m2MaQQFBSGp+XA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
+      "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
       "dev": true,
       "requires": {
         "ajv": "6.12.6",
@@ -391,12 +411,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.1.tgz",
-      "integrity": "sha512-XYbC0cGPChdXg0LD9EA08W24Rv5GPxGNGJNRQhUwlcU9L/szhOw9NEhr/l/DLijAxKv0J2eM5CuzKI1O/3tZYg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.2.tgz",
+      "integrity": "sha512-wIWI4+EPsjbN+23Rs0zE4GarKrUm8gMR3MpGAtlEmGG2ZsXEVdfiKUebBdWGrx0sEfgLN9JfePbZQFvqN5ifyw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/core": "11.1.2",
         "ora": "5.2.0",
         "rxjs": "6.6.3"
       },
@@ -501,16 +521,16 @@
       }
     },
     "@angular/cli": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.1.1.tgz",
-      "integrity": "sha512-2nRx9KYzLVCtJA4pgDmxubHOp54O/74BYt3WGHAA7QcnSATEL7jF5a9SMoEAJ2sUtKUVVS+2dKbmYKwW6oL3Bw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.1.2.tgz",
+      "integrity": "sha512-qOAkxCzBPm+QdXpSHxLERw1Vag8S0JHMY0zCwtG63XFvwHZCIihHRkOR3xHDWlVnGTmnUixg4Mt5s/4GGPuDJg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.1",
-        "@angular-devkit/core": "11.1.1",
-        "@angular-devkit/schematics": "11.1.1",
-        "@schematics/angular": "11.1.1",
-        "@schematics/update": "0.1101.1",
+        "@angular-devkit/architect": "0.1101.2",
+        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/schematics": "11.1.2",
+        "@schematics/angular": "11.1.2",
+        "@schematics/update": "0.1101.2",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.3.1",
@@ -958,15 +978,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001179",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
-          "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
+          "version": "1.0.30001180",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz",
+          "integrity": "sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.643",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.643.tgz",
-          "integrity": "sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==",
+          "version": "1.3.648",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.648.tgz",
+          "integrity": "sha512-4POzwyQ80tkDiBwkxn7IpfzioimrjRSFX1sCQ3pLZsYJ5ERYmwzdq0hZZ3nFP7Z6GtmnSn3xwWDm8FPlMeOoEQ==",
           "dev": true
         },
         "node-releases": {
@@ -1962,12 +1982,12 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.1.tgz",
-      "integrity": "sha512-SoqZU8qNESwuJbiYJoRhp/aMyWeK4HClkwotqkM/bPUnnOOCRvDYP20vYhATivF8Y8xOL7wktdd1HOtFvtbvlA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.2.tgz",
+      "integrity": "sha512-x/HVx4doKu4gAwGGk+C89JCFe5GF8Te7I7uvwMTqEXr+Ua9YHYvN/q2IwLdhIXPB4ilBSIjrb9zm05yBvBTAeg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.1",
+        "@angular-devkit/core": "11.1.2",
         "enhanced-resolve": "5.6.0",
         "webpack-sources": "2.2.0"
       }
@@ -2060,13 +2080,13 @@
       }
     },
     "@npmcli/move-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.0.tgz",
-      "integrity": "sha512-Iv2iq0JuyYjKeFkSR4LPaCdDZwlGK9X2cP/01nJcp3yMJ1FjNd9vpiEYvLUgzBxKPg2SFmaOhizoQsPc0LWeOQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.1.tgz",
+      "integrity": "sha512-LtWTicuF2wp7PNTuyCwABx7nNG+DnzSE8gN0iWxkC6mpgm/iOPu0ZMTkXuCxmJxtWFsDxUaixM9COSNJEMUfuQ==",
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
-        "rimraf": "^2.7.1"
+        "rimraf": "^3.0.2"
       },
       "dependencies": {
         "mkdirp": {
@@ -2074,15 +2094,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -2217,24 +2228,24 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.1.tgz",
-      "integrity": "sha512-K4G+PwCIGYE6aw28ZcqAhw+qI6I8d8qtE3D1Vd4MPVuguDWpNEaB0Y+TIYWzukh5bmOqdl9m/fkw6eZeOglUuQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.2.tgz",
+      "integrity": "sha512-ZhaB/QBwfWsvZYJplLH8VK/7vnFpUbk1nptjC106K/I38xlmWdB4pStLJK94eyJk0KlItnsPvE0a9KuLPKA/Ow==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.1",
-        "@angular-devkit/schematics": "11.1.1",
+        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/schematics": "11.1.2",
         "jsonc-parser": "3.0.0"
       }
     },
     "@schematics/update": {
-      "version": "0.1101.1",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1101.1.tgz",
-      "integrity": "sha512-BmGxxAH05ey8rc0gQpMJ7hAJyr7bM172MStpIws+MLugxZ6a6jH8vI1+MpnrqE0TK1PIPx6vclCMgf3RbQEzIw==",
+      "version": "0.1101.2",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1101.2.tgz",
+      "integrity": "sha512-WwMsIkhR3hq7gvfB5HsuTK2Sz9iZmpz0/AiFYRJbX+mXL/KgONcridyorW45Dg1Q2sRXVGiAUxWsQYzjmeLO7g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.1",
-        "@angular-devkit/schematics": "11.1.1",
+        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/schematics": "11.1.2",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "2.0.0",
         "npm-package-arg": "^8.0.0",
@@ -4225,15 +4236,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001179",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
-          "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
+          "version": "1.0.30001180",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz",
+          "integrity": "sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.643",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.643.tgz",
-          "integrity": "sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==",
+          "version": "1.3.648",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.648.tgz",
+          "integrity": "sha512-4POzwyQ80tkDiBwkxn7IpfzioimrjRSFX1sCQ3pLZsYJ5ERYmwzdq0hZZ3nFP7Z6GtmnSn3xwWDm8FPlMeOoEQ==",
           "dev": true
         },
         "node-releases": {
@@ -5744,9 +5755,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
-      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -5906,9 +5917,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
       "dev": true
     },
     "for-in": {
@@ -6100,9 +6111,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -8612,9 +8623,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+          "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -12147,9 +12158,9 @@
       }
     },
     "ssri": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "dev": true,
       "requires": {
         "minipass": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/itzrabbs/angular-2-dropdown-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1101.1",
+    "@angular-devkit/build-angular": "^0.1101.2",
     "@angular/animations": "11.1.1",
-    "@angular/cli": "^11.1.1",
+    "@angular/cli": "^11.1.2",
     "@angular/common": "11.1.1",
     "@angular/compiler": "11.1.1",
     "@angular/compiler-cli": "11.1.1",


### PR DESCRIPTION
[ng-update](https://github.com/itzrabbs/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 21 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       11.1.1 -> 11.1.2         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>