### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,42 +5,43 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1101.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.4.tgz",
-      "integrity": "sha512-yur0mX156ZX1aXE7d8Z1z6sYjDk771iCyijLCN8MCx35lHIPGwMZwsB/dkttTChVHS8wJ+9YZnIucEBoh9ij3g==",
+      "version": "0.1102.0",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.0.tgz",
+      "integrity": "sha512-d9Da6SiTiDb5N1avxWLcPHSyWCq3G62TlROXxr32WkcQRko8wtgW5VOzgSkdmY2p6UTSME89naUojfzgu2Wh6g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.4",
+        "@angular-devkit/core": "11.2.0",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1101.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.4.tgz",
-      "integrity": "sha512-iH4JMAmNazsWb7wF++3dIPIn1hJUqvidWPfBIHm6AyGLVvCQoAHVnK4Zp07NaCRnpu8ZVlrADJqmSQ3coYYVvg==",
+      "version": "0.1102.0",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1102.0.tgz",
+      "integrity": "sha512-9Yl6qBOR1o0ThyLhrWJ6Rhr3qLRe+RP3sbfUt4QA+8wsIXN7WakEXJALlq7TDeG66OaWyyjbtC2q3EPdNeBC/g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.4",
-        "@angular-devkit/build-optimizer": "0.1101.4",
-        "@angular-devkit/build-webpack": "0.1101.4",
-        "@angular-devkit/core": "11.1.4",
+        "@angular-devkit/architect": "0.1102.0",
+        "@angular-devkit/build-optimizer": "0.1102.0",
+        "@angular-devkit/build-webpack": "0.1102.0",
+        "@angular-devkit/core": "11.2.0",
         "@babel/core": "7.12.10",
         "@babel/generator": "7.12.11",
+        "@babel/plugin-transform-async-to-generator": "7.12.1",
         "@babel/plugin-transform-runtime": "7.12.10",
         "@babel/preset-env": "7.12.11",
         "@babel/runtime": "7.12.5",
         "@babel/template": "7.12.7",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.1.4",
+        "@ngtools/webpack": "11.2.0",
         "ansi-colors": "4.1.1",
-        "autoprefixer": "10.2.1",
+        "autoprefixer": "10.2.4",
         "babel-loader": "8.2.2",
         "browserslist": "^4.9.1",
         "cacache": "15.0.5",
         "caniuse-lite": "^1.0.30001032",
         "circular-dependency-plugin": "5.2.2",
         "copy-webpack-plugin": "6.3.2",
-        "core-js": "3.8.2",
+        "core-js": "3.8.3",
         "critters": "0.0.6",
         "css-loader": "5.0.1",
         "cssnano": "4.1.10",
@@ -51,14 +52,14 @@
         "inquirer": "7.3.3",
         "jest-worker": "26.6.2",
         "karma-source-map-support": "1.4.0",
-        "less": "4.1.0",
+        "less": "4.1.1",
         "less-loader": "7.3.0",
         "license-webpack-plugin": "2.3.11",
         "loader-utils": "2.0.0",
-        "mini-css-extract-plugin": "1.3.3",
+        "mini-css-extract-plugin": "1.3.5",
         "minimatch": "3.0.4",
-        "open": "7.3.1",
-        "ora": "5.2.0",
+        "open": "7.4.0",
+        "ora": "5.3.0",
         "parse5-html-rewriting-stream": "6.0.1",
         "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.2.4",
@@ -68,25 +69,25 @@
         "regenerator-runtime": "0.13.7",
         "resolve-url-loader": "3.1.2",
         "rimraf": "3.0.2",
-        "rollup": "2.36.1",
+        "rollup": "2.38.4",
         "rxjs": "6.6.3",
-        "sass": "1.32.4",
+        "sass": "1.32.6",
         "sass-loader": "10.1.1",
         "semver": "7.3.4",
         "source-map": "0.7.3",
         "source-map-loader": "1.1.3",
         "source-map-support": "0.5.19",
-        "speed-measure-webpack-plugin": "1.3.3",
+        "speed-measure-webpack-plugin": "1.4.2",
         "style-loader": "2.0.0",
         "stylus": "0.54.8",
-        "stylus-loader": "4.3.2",
+        "stylus-loader": "4.3.3",
         "terser": "5.5.1",
         "terser-webpack-plugin": "4.2.3",
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "webpack": "4.44.2",
         "webpack-dev-middleware": "3.7.2",
-        "webpack-dev-server": "3.11.1",
+        "webpack-dev-server": "3.11.2",
         "webpack-merge": "5.7.3",
         "webpack-sources": "2.2.0",
         "webpack-subresource-integrity": "1.5.2",
@@ -102,86 +103,12 @@
             "debug": "4"
           }
         },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "autoprefixer": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.1.tgz",
-          "integrity": "sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.1",
-            "caniuse-lite": "^1.0.30001173",
-            "colorette": "^1.2.1",
-            "fraction.js": "^4.0.13",
-            "normalize-range": "^0.1.2",
-            "postcss-value-parser": "^4.1.0"
-          },
-          "dependencies": {
-            "browserslist": {
-              "version": "4.16.3",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-              "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
-              "dev": true,
-              "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
-                "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
-              }
-            },
-            "caniuse-lite": {
-              "version": "1.0.30001185",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
-              "integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
-              "dev": true
-            }
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.657",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz",
-          "integrity": "sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw==",
-          "dev": true
+          "optional": true
         },
         "glob": {
           "version": "7.1.6",
@@ -197,12 +124,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
         "https-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -211,55 +132,6 @@
           "requires": {
             "agent-base": "6",
             "debug": "4"
-          }
-        },
-        "less": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/less/-/less-4.1.0.tgz",
-          "integrity": "sha512-w1Ag/f34g7LwtQ/sMVSGWIyZx+gG9ZOAEtyxeX1fG75is6BMyC2lD5kG+1RueX7PkAvlQBm2Lf2aN2j0JbVr2A==",
-          "dev": true,
-          "requires": {
-            "copy-anything": "^2.0.1",
-            "errno": "^0.1.1",
-            "graceful-fs": "^4.1.2",
-            "image-size": "~0.5.0",
-            "make-dir": "^2.1.0",
-            "mime": "^1.4.1",
-            "needle": "^2.5.2",
-            "parse-node-version": "^1.0.1",
-            "source-map": "~0.6.0",
-            "tslib": "^1.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "node-releases": {
-          "version": "1.1.70",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
-          "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
-          "dev": true
-        },
-        "ora": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-5.2.0.tgz",
-          "integrity": "sha512-+wG2v8TUU8EgzPHun1k/n45pXquQ9fHnbXVetl9rRgO6kjZszGGbraF3XPTIdgeA+s1lbRjSEftAnyT0w8ZMvQ==",
-          "dev": true,
-          "requires": {
-            "bl": "^4.0.3",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-spinners": "^2.5.0",
-            "is-interactive": "^1.0.0",
-            "log-symbols": "^4.0.0",
-            "strip-ansi": "^6.0.0",
-            "wcwidth": "^1.0.1"
           }
         },
         "postcss": {
@@ -282,18 +154,18 @@
           }
         },
         "rollup": {
-          "version": "2.36.1",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
-          "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
+          "version": "2.38.4",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz",
+          "integrity": "sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==",
           "dev": true,
           "requires": {
-            "fsevents": "~2.1.2"
+            "fsevents": "~2.3.1"
           }
         },
         "sass": {
-          "version": "1.32.4",
-          "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.4.tgz",
-          "integrity": "sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==",
+          "version": "1.32.6",
+          "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
+          "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
           "dev": true,
           "requires": {
             "chokidar": ">=2.0.0 <4.0.0"
@@ -307,31 +179,13 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1101.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.4.tgz",
-      "integrity": "sha512-2IdpwftE4ERcfc4TynWVuZkSu5L7BHDgBVktNYjINheqo0zU0fw01Y6rn9R9lKzsn3ka4GWP2hwnA1T1WWGl9A==",
+      "version": "0.1102.0",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1102.0.tgz",
+      "integrity": "sha512-0Xb7xR0iUrbo/BnKJPTsy5IuodfFUWbvXUu9qeKc+oHzwxObX4Y32X0yyRpIJc5UK7Ce43HkopRQ/tHdoJp2fQ==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
@@ -356,20 +210,20 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1101.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.4.tgz",
-      "integrity": "sha512-wc8Nw9ZNUBK5XwFFmtkKdPvRRMInOYe4pyk8b+OcLEGOQgJlAaP2/rXdceI7V227DLaKpqzYL0Tx10cfsq9Iqw==",
+      "version": "0.1102.0",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1102.0.tgz",
+      "integrity": "sha512-bfd6WlxcbWJ01HNNcFt4sBBaY+Bz2J/zFA6BSORvC5LpqawYCYeUbDJTY9Wb7gtp+aPEiNHI0HeUvoNkubsYfg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.4",
-        "@angular-devkit/core": "11.1.4",
+        "@angular-devkit/architect": "0.1102.0",
+        "@angular-devkit/core": "11.2.0",
         "rxjs": "6.6.3"
       }
     },
     "@angular-devkit/core": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.4.tgz",
-      "integrity": "sha512-xqjUIdMTDNjZ8jkzlDSQbhmTwF2tOLlT0iRI9mb7pN4VIS0LI/Xu0iTqDUrVs0Hqtb9609dz13LXu5zbQSb+cw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.0.tgz",
+      "integrity": "sha512-qqYEH8m/bwpngoLDMFuth8ykvoHxQ3aHHnAWfRXz9NXydwSfathG0VSYCctB126sK39JKIn+xq16CQAExxNu+Q==",
       "dev": true,
       "requires": {
         "ajv": "6.12.6",
@@ -406,96 +260,14 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.1.4.tgz",
-      "integrity": "sha512-WWHmBHPabKgrBDM2M5ayA0OdhonNQHld8NjY8jEdwyWI4xEj23C/qDfgQc8sssvpi4LauKSaPozDELl7ItBPXA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.0.tgz",
+      "integrity": "sha512-sMDacACJbA4pykiqgJf/RdW0damcf4mDqErGgEqs/bGG+SBUb8+wgt4cQnUwwVX5V2nMdvv7f0A84rgR6I3G2w==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.4",
-        "ora": "5.2.0",
+        "@angular-devkit/core": "11.2.0",
+        "ora": "5.3.0",
         "rxjs": "6.6.3"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "ora": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-5.2.0.tgz",
-          "integrity": "sha512-+wG2v8TUU8EgzPHun1k/n45pXquQ9fHnbXVetl9rRgO6kjZszGGbraF3XPTIdgeA+s1lbRjSEftAnyT0w8ZMvQ==",
-          "dev": true,
-          "requires": {
-            "bl": "^4.0.3",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-spinners": "^2.5.0",
-            "is-interactive": "^1.0.0",
-            "log-symbols": "^4.0.0",
-            "strip-ansi": "^6.0.0",
-            "wcwidth": "^1.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@angular/animations": {
@@ -516,16 +288,16 @@
       }
     },
     "@angular/cli": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.1.4.tgz",
-      "integrity": "sha512-IGGKtMWtUBkEEzFcd0wP/SFricOg5Mc0l7BG4m6kRtCU34wQVbvc5h6xQIGrhKOJyLQ/gGZkqSWY+21Hun5jgQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.2.0.tgz",
+      "integrity": "sha512-waIR5Nqc2wcYXZh/Mgm+4Iyvu0nzKAhvmKiJjcJ+f2UuPRMLdNAInTvhdpfgKaNdmiArxNa6UntRIu+EavGc9Q==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.4",
-        "@angular-devkit/core": "11.1.4",
-        "@angular-devkit/schematics": "11.1.4",
-        "@schematics/angular": "11.1.4",
-        "@schematics/update": "0.1101.4",
+        "@angular-devkit/architect": "0.1102.0",
+        "@angular-devkit/core": "11.2.0",
+        "@angular-devkit/schematics": "11.2.0",
+        "@schematics/angular": "11.2.0",
+        "@schematics/update": "0.1102.0",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.3.1",
@@ -534,8 +306,9 @@
         "jsonc-parser": "3.0.0",
         "npm-package-arg": "8.1.0",
         "npm-pick-manifest": "6.1.0",
-        "open": "7.3.1",
-        "pacote": "11.1.14",
+        "open": "7.4.0",
+        "ora": "5.3.0",
+        "pacote": "11.2.4",
         "resolve": "1.19.0",
         "rimraf": "3.0.2",
         "semver": "7.3.4",
@@ -975,13 +748,13 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.13.tgz",
-      "integrity": "sha512-dXof20y/6wB5HnLOGyLh/gobsMvDNoekcC+8MCV2iaTd5JemhFkPD73QB+tK3iFC9P0xJC73B6MvKkyUfS9cCw==",
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.16.tgz",
+      "integrity": "sha512-dBHNEEaZx7F3KoUYqagIhRIeqyyuI65xMndMZ3WwGwEBI609I4TleYQHcrS627vbKyNTXqShoN+fvYD9HuQxAg==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.12.13",
-        "@babel/helper-validator-option": "^7.12.11",
+        "@babel/helper-validator-option": "^7.12.16",
         "browserslist": "^4.14.5",
         "semver": "^5.5.0"
       },
@@ -1006,9 +779,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.657",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz",
-          "integrity": "sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw==",
+          "version": "1.3.663",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.663.tgz",
+          "integrity": "sha512-xkVkzHj6k3oRRGlmdgUCCLSLhtFYHDCTH7SeK+LJdJjnsLcrdbpr8EYmfMQhez3V/KPO5UScSpzQ0feYX6Qoyw==",
           "dev": true
         },
         "node-releases": {
@@ -1026,13 +799,13 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.13.tgz",
-      "integrity": "sha512-Vs/e9wv7rakKYeywsmEBSRC9KtmE7Px+YBlESekLeJOF0zbGUicGfXSNi3o+tfXSNS48U/7K9mIOOCR79Cl3+Q==",
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.16.tgz",
+      "integrity": "sha512-KbSEj8l9zYkMVHpQqM3wJNxS1d9h3U9vm/uE5tpjMbaj3lTp+0noe3KPsV5dSD9jxKnf9jO9Ip9FX5PKNZCKow==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
+        "@babel/helper-member-expression-to-functions": "^7.12.16",
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/helper-replace-supers": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13"
@@ -1079,9 +852,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -1135,9 +908,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -1188,9 +961,9 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.13.tgz",
-      "integrity": "sha512-XC+kiA0J3at6E85dL5UnCYfVOcIZ834QcAY0TIpgUVnz0zDzg+0TtvZTnJ4g9L1dPRGe30Qi03XCIS4tYCLtqw==",
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.16.tgz",
+      "integrity": "sha512-jAcQ1biDYZBdaAxB4yg46/XirgX7jBDiMHDbwYQOgtViLBXGxJpZQ24jutmBqAIB/q+AwB6j+NbBXjKxEY8vqg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
@@ -1399,9 +1172,9 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
-      "integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==",
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.16.tgz",
+      "integrity": "sha512-uCgsDBPUQDvzr11ePPo4TVEocxj8RXjUVSC/Y8N1YpVAI/XDdUwGJu78xmlGhTxj2ntaWM7n9LQdRtyhOzT2YQ==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
@@ -1483,9 +1256,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -1585,12 +1358,12 @@
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
-      "integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.16.tgz",
+      "integrity": "sha512-yiDkYFapVxNOCcBfLnsb/qdsliroM+vc3LHiZwS4gh7pFjo5Xq3BDhYBNn3H3ao+hWPvqeeTdU+s+FIvokov+w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0"
       }
     },
@@ -1666,9 +1439,9 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.13.tgz",
-      "integrity": "sha512-0ZwjGfTcnZqyV3y9DSD1Yk3ebp+sIUpT2YDqP8hovzaNZnQq2Kd7PEqa6iOIUDBXBt7Jl3P7YAcEIL5Pz8u09Q==",
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.16.tgz",
+      "integrity": "sha512-O3ohPwOhkwji5Mckb7F/PJpJVJY3DpPsrt/F0Bk40+QMk9QpAIqeGusHWqu/mYqsM8oBa6TziL/2mbERWsUZjg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13",
@@ -1814,42 +1587,14 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.13.tgz",
-      "integrity": "sha512-psM9QHcHaDr+HZpRuJcE1PXESuGWSCcbiGFFhhwfzdbTxaGDVzuVtdNYliAwcRo3GFg0Bc8MmI+AvIGYIJG04A==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+      "integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/helper-remap-async-to-generator": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-          "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.13"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-          "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.12.1"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -1926,9 +1671,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -1982,9 +1727,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -2147,9 +1892,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -2246,9 +1991,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -2337,9 +2082,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -2442,9 +2187,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -2533,9 +2278,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -2639,9 +2384,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -2730,9 +2475,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -2833,9 +2578,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -2924,9 +2669,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -3045,9 +2790,9 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
-          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
+          "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -3101,9 +2846,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.12.15",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
-          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "version": "7.12.16",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
+          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
           "dev": true
         },
         "@babel/template": {
@@ -3455,13 +3200,13 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.4.tgz",
-      "integrity": "sha512-fM17s/mGY/DV9/a/d3lsFiZdL8PfKRY0VGPHCujBIWv9KQg1gUUNkbTepFaNPCBK/bWDH/fIXuNRIHhy1NUeIA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.2.0.tgz",
+      "integrity": "sha512-2KYaA/fIw863jydXDolWp4kUNLODVIKs2834vW+oztocnYFe/z4dTz6rArKFUCixMCu12ieXrjAetzGA564bsg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.4",
-        "enhanced-resolve": "5.6.0",
+        "@angular-devkit/core": "11.2.0",
+        "enhanced-resolve": "5.7.0",
         "webpack-sources": "2.2.0"
       }
     },
@@ -3498,9 +3243,9 @@
       "dev": true
     },
     "@npmcli/git": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.4.tgz",
-      "integrity": "sha512-OJZCmJ9DNn1cz9HPXXsPmUBnqaArot3CGYo63CyajHQk+g87rPXVOJByGsskQJhPsUUEXJcsZ2Q6bWd2jSwnBA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.6.tgz",
+      "integrity": "sha512-a1MnTfeRPBaKbFY07fd+6HugY1WAkKJzdiJvlRub/9o5xz2F/JtPacZZapx5zRJUQFIzSL677vmTSxEcDMrDbg==",
       "dev": true,
       "requires": {
         "@npmcli/promise-spawn": "^1.1.0",
@@ -3508,7 +3253,7 @@
         "mkdirp": "^1.0.3",
         "npm-pick-manifest": "^6.0.0",
         "promise-inflight": "^1.0.1",
-        "promise-retry": "^1.1.1",
+        "promise-retry": "^2.0.1",
         "semver": "^7.3.2",
         "unique-filename": "^1.1.1",
         "which": "^2.0.2"
@@ -3519,6 +3264,16 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
+        },
+        "promise-retry": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+          "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+          "dev": true,
+          "requires": {
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
+          }
         },
         "semver": {
           "version": "7.3.4",
@@ -3541,33 +3296,19 @@
       }
     },
     "@npmcli/installed-package-contents": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.6.tgz",
-      "integrity": "sha512-mpAxU8XZbhyqD1N9/fw1vS5wpKTWREDpUrTPdyQUJOT1PRXIM+DsK3Tpiftvvfi1lmvrRD2HusE2ohgGKvo3UA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
       "dev": true,
       "requires": {
         "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1",
-        "read-package-json-fast": "^2.0.1",
-        "readdir-scoped-modules": "^1.1.0"
-      },
-      "dependencies": {
-        "read-package-json-fast": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.1.tgz",
-          "integrity": "sha512-bp6z0tdgLy9KzdfENDIw/53HWAolOVoQTRWXv7PUiqAo3YvvoUVeLr7RWPWq+mu7KUOu9kiT4DvxhUgNUBsvug==",
-          "dev": true,
-          "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        }
+        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "@npmcli/move-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.1.tgz",
-      "integrity": "sha512-LtWTicuF2wp7PNTuyCwABx7nNG+DnzSE8gN0iWxkC6mpgm/iOPu0ZMTkXuCxmJxtWFsDxUaixM9COSNJEMUfuQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
@@ -3583,9 +3324,9 @@
       }
     },
     "@npmcli/node-gyp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz",
-      "integrity": "sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz",
+      "integrity": "sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==",
       "dev": true
     },
     "@npmcli/promise-spawn": {
@@ -3598,12 +3339,12 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.2.tgz",
-      "integrity": "sha512-iwKq152Q62zG2rz/zRqT/OLDKcF1nBGTGmFdHRkTV8JRte6bUt18vPG4vOr/uoECecrIuJe1SSyvuUF32yt5BA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.3.tgz",
+      "integrity": "sha512-ELPGWAVU/xyU+A+H3pEPj0QOvYwLTX71RArXcClFzeiyJ/b/McsZ+d0QxpznvfFtZzxGN/gz/1cvlqICR4/suQ==",
       "dev": true,
       "requires": {
-        "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
         "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
@@ -3725,28 +3466,28 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.1.4.tgz",
-      "integrity": "sha512-UWhUPxRarbK4AWTcOBmCOYMZwuxnJRo/Ts/0yyNqUkj6gHieyv0hsOi10f8Ofn34MyvPnUpDnCT/o9bzanmqog==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.0.tgz",
+      "integrity": "sha512-PtbyZ7TEEEae9Y5siSZYigWyk8iOSjZ10ThA7tRxm8gdcLjGimyyKr5TyjufIAvrXIYnBXNLgPkZG6s5CQIEyw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.4",
-        "@angular-devkit/schematics": "11.1.4",
+        "@angular-devkit/core": "11.2.0",
+        "@angular-devkit/schematics": "11.2.0",
         "jsonc-parser": "3.0.0"
       }
     },
     "@schematics/update": {
-      "version": "0.1101.4",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1101.4.tgz",
-      "integrity": "sha512-aEb/kqNgdVZ53lGQBIE4vPBGwlnqv2hRp3dyrhe++PJOyQf4cf0iJwfL0tB3pSHwjialaHtsrMybOs0a/81alA==",
+      "version": "0.1102.0",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1102.0.tgz",
+      "integrity": "sha512-2hFt/2iPe6LqQvzYj4HvQ8us0e0lBU75rSK2yY6VfiZWR/qo7yk99YKI7JWFTLvLsNbhNnSG/9opXJHqqUoc3g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.4",
-        "@angular-devkit/schematics": "11.1.4",
+        "@angular-devkit/core": "11.2.0",
+        "@angular-devkit/schematics": "11.2.0",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "2.0.0",
         "npm-package-arg": "^8.0.0",
-        "pacote": "11.1.14",
+        "pacote": "11.2.4",
         "semver": "7.3.4",
         "semver-intersect": "1.4.0"
       },
@@ -4307,12 +4048,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -5696,9 +5431,9 @@
       }
     },
     "core-js": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
-      "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
       "dev": true
     },
     "core-js-compat": {
@@ -5731,9 +5466,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.657",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz",
-          "integrity": "sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw==",
+          "version": "1.3.663",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.663.tgz",
+          "integrity": "sha512-xkVkzHj6k3oRRGlmdgUCCLSLhtFYHDCTH7SeK+LJdJjnsLcrdbpr8EYmfMQhez3V/KPO5UScSpzQ0feYX6Qoyw==",
           "dev": true
         },
         "node-releases": {
@@ -6025,9 +5760,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "8.2.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.5.tgz",
-          "integrity": "sha512-wMcb7BpDcm3gxQOQx46NDNT36Kk0Ao6PJLLI2ed5vehbbbxCEuslSQzbQ2sfSKy+gkYxhWcGWSeaK+gwm4KIZg==",
+          "version": "8.2.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.6.tgz",
+          "integrity": "sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==",
           "dev": true,
           "requires": {
             "colorette": "^1.2.1",
@@ -6270,12 +6005,6 @@
         "ms": "2.1.2"
       }
     },
-    "debuglog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-      "dev": true
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -6483,16 +6212,6 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
-    },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -6709,9 +6428,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.6.0.tgz",
-      "integrity": "sha512-C3GGDfFZmqUa21o10YRKbZN60DPl0HyXKXxoEnQMWso9u7KMU23L7CBHfr/rVxORddY/8YQZaU2MZ1ewTS8Pcw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
+      "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -6719,9 +6438,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
-          "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
           "dev": true
         }
       }
@@ -6739,9 +6458,9 @@
       "dev": true
     },
     "err-code": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
     },
     "errno": {
@@ -7093,9 +6812,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.2.0.tgz",
+          "integrity": "sha512-M/u37b4oSGlusaU8ZB96BfFPWQ8MbsZYXB+kXGMiDj6IKinkcNaQvmirBuWj8mAXqP6LYn1rQvbTYum3yPhaOA==",
           "dev": true
         }
       }
@@ -9186,9 +8905,9 @@
       }
     },
     "make-fetch-happen": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.13.tgz",
-      "integrity": "sha512-rQ5NijwwdU8tIaBrpTtSVrNCcAJfyDRcKBC76vOQlyJX588/88+TE+UpjWl4BgG7gCkp29wER7xcRqkeg+x64Q==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
+      "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^4.1.3",
@@ -9203,7 +8922,7 @@
         "minipass-fetch": "^1.3.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "promise-retry": "^1.1.1",
+        "promise-retry": "^2.0.1",
         "socks-proxy-agent": "^5.0.0",
         "ssri": "^8.0.0"
       },
@@ -9225,6 +8944,16 @@
           "requires": {
             "agent-base": "6",
             "debug": "4"
+          }
+        },
+        "promise-retry": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+          "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+          "dev": true,
+          "requires": {
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
           }
         }
       }
@@ -9374,9 +9103,9 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.3.tgz",
-      "integrity": "sha512-7lvliDSMiuZc81kI+5/qxvn47SCM7BehXex3f2c6l/pR3Goj58IQxZh9nuPQ3AkGQgoETyXuIqLDaO5Oa0TyBw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.5.tgz",
+      "integrity": "sha512-tvmzcwqJJXau4OQE5vT72pRT18o2zF+tQJp8CWchqvfQnTlflkzS+dANYcRdyPRWUWRkfmeNTKltx0NZI/b5dQ==",
       "dev": true,
       "requires": {
         "loader-utils": "^2.0.0",
@@ -10437,9 +10166,9 @@
       }
     },
     "open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.0.tgz",
+      "integrity": "sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -10615,9 +10344,9 @@
       "dev": true
     },
     "pacote": {
-      "version": "11.1.14",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.1.14.tgz",
-      "integrity": "sha512-6c5OhQelaJFDfiw/Zd8MfGCvvFHurSdeGzufZMPvRFImdbNOYFciOINf3DtUNUaU3h98eCb749UyHDsgvL19+A==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.2.4.tgz",
+      "integrity": "sha512-GfTeVQGJ6WyBQbQD4t3ocHbyOmTQLmWjkCKSZPmKiGFKYKNUaM5U2gbLzUW8WG1XmS9yQFnsTFA0k3o1+q4klQ==",
       "dev": true,
       "requires": {
         "@npmcli/git": "^2.0.1",
@@ -11762,6 +11491,12 @@
         "retry": "^0.10.0"
       },
       "dependencies": {
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+          "dev": true
+        },
         "retry": {
           "version": "0.10.1",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
@@ -12225,6 +11960,12 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12329,9 +12070,9 @@
       }
     },
     "read-package-json-fast": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-1.2.1.tgz",
-      "integrity": "sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-1.2.2.tgz",
+      "integrity": "sha512-39DbPJjkltEzfXJXB6D8/Ir3GFOU2YbSKa2HaB/Y3nKrc/zY+0XrALpID6/13ezWyzqvOHrBbR4t4cjQuTdBVQ==",
       "dev": true,
       "requires": {
         "json-parse-even-better-errors": "^2.3.0",
@@ -12393,18 +12134,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "readdir-scoped-modules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
-      "dev": true,
-      "requires": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -12817,10 +12546,13 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "run-queue": {
       "version": "1.0.3",
@@ -13670,12 +13402,63 @@
       }
     },
     "speed-measure-webpack-plugin": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.3.tgz",
-      "integrity": "sha512-2ljD4Ch/rz2zG3HsLsnPfp23osuPBS0qPuz9sGpkNXTN1Ic4M+W9xB8l8rS8ob2cO4b1L+WTJw/0AJwWYVgcxQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.4.2.tgz",
+      "integrity": "sha512-AtVzD0bnIy2/B0fWqJpJgmhcrfWFhBlduzSo0uwplr/QvB33ZNZj2NEth3NONgdnZJqicK0W0mSxnLSbsVCDbw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "split-string": {
@@ -13982,9 +13765,9 @@
       }
     },
     "stylus-loader": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.2.tgz",
-      "integrity": "sha512-xXVKHY+J7GBlOmqjCL1VvQfc+pFkBdWGtcpJSvBGE49nWWHaukox7KCjRdLTEzjrmHODm4+rLpqkYWzfJteMXQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.3.tgz",
+      "integrity": "sha512-PpWB5PnCXUzW4WMYhCvNzAHJBjIBPMXwsdfkkKuA9W7k8OQFMl/19/AQvaWsxz2IptxUlCseyJ6TY/eEKJ4+UQ==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.4",
@@ -15395,9 +15178,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
-      "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/itzrabbs/angular-2-dropdown-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1101.4",
+    "@angular-devkit/build-angular": "^0.1102.0",
     "@angular/animations": "11.2.0",
-    "@angular/cli": "^11.1.4",
+    "@angular/cli": "^11.2.0",
     "@angular/common": "11.2.0",
     "@angular/compiler": "11.2.0",
     "@angular/compiler-cli": "11.2.0",


### PR DESCRIPTION
[ng-update](https://github.com/itzrabbs/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 21 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       11.1.4 -> 11.2.0         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>